### PR TITLE
Add timeout to keystone_dbsync command

### DIFF
--- a/keystone/server.sls
+++ b/keystone/server.sls
@@ -198,6 +198,7 @@ keystone_entrypoint:
 keystone_syncdb:
   cmd.run:
   - name: keystone-manage db_sync; sleep 1
+  - timeout: 60
   - require:
     - service: keystone_service
 {%- endif %}


### PR DESCRIPTION
The keystone_dbsync command is stuck if for example database is not accessible and we should kill it after some timeout to prevent further issue with salt-minion.